### PR TITLE
Access rutgers theme directly from Xaringan

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ date: "Rutgers University </br> `r Sys.Date()`"
 output:
   xaringan::moon_reader:
     lib_dir: libs
-    css: ["http://www.jvcasillas.com/ru_xaringan/css/rutgers.css", "http://www.jvcasillas.com/ru_xaringan/css/rutgers-fonts.css"]
+    css: ["rutgers", "rutgers-fonts"]
     nature:
       beforeInit: "http://www.jvcasillas.com/ru_xaringan/js/ru_xaringan.js"
       highlightStyle: github


### PR DESCRIPTION
The rutgers theme was added to Xaringan a few days ago. You access the theme using the changes I made to your README file (line 24). Make sure you update xaringan to the latest version.